### PR TITLE
set retry time for importing process model into analyzer to 10 minutes

### DIFF
--- a/pipeline/src/main/java/de/viadee/vpw/pipeline/listener/ProcessDefinitionEventListener.java
+++ b/pipeline/src/main/java/de/viadee/vpw/pipeline/listener/ProcessDefinitionEventListener.java
@@ -51,7 +51,7 @@ public class ProcessDefinitionEventListener {
     }
 
     @Retryable(recover = "shutdown", value = RestClientException.class,
-            maxAttempts = 12, backoff = @Backoff(delay = 5000))
+            maxAttempts = 120, backoff = @Backoff(delay = 5000))
     public void importProcessDefinition(ProcessDefinitionEvent event, Acknowledgment acknowledgment) {
 
         String processDefinitionId = event.getId();


### PR DESCRIPTION
Waiting one minute for the analyzer to start may be not enough in some environments.
Adjusting the Retryable to 120 * 5 seconds should be sufficient.